### PR TITLE
Add arrowup and arrowdown key listener

### DIFF
--- a/src/app/[reviewId]/page.tsx
+++ b/src/app/[reviewId]/page.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
 import type { Tables } from "@/src/types/database.types";
-import Test from "../../components/Test";
 import EditField from "../../components/EditField";
 import FlashcardView from "../../components/FlashcardView";
+import Test from "../../components/Test";
 import { createClient } from "../../lib/supabase/server";
 
 export default async function ReviewPage({

--- a/src/components/Flashcard.tsx
+++ b/src/components/Flashcard.tsx
@@ -41,7 +41,7 @@ export default function Flashcard({
     const handleKeyDown = (e: KeyboardEvent) => {
       const tag = document.activeElement?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
-      if (e.key === " ") {
+      if (e.key === " " || e.key === "ArrowUp" || e.key === "ArrowDown") {
         e.preventDefault();
         setIsFlipped((prev) => !prev);
       }

--- a/src/components/Test.tsx
+++ b/src/components/Test.tsx
@@ -89,7 +89,10 @@ export default function Test({ questions: initialQuestions, reviewId }: TestProp
               onDragEnd={() => setActiveId(null)}
               onDragOver={(e) => handleDragOver(e, q.id)}
               onDrop={handleDrop}
-              className={`${activeId === q.id ? "cursor-grabbing" : ""} ${isAnyEditing ? "cursor-default" : "cursor-grab"
+              className={`transition-[opacity,transform,box-shadow] duration-150 ${activeId === q.id
+                ? "cursor-grabbing opacity-0"
+                : ""
+                } ${isAnyEditing ? "cursor-default" : "cursor-grab"
                 }`}
             >
               <div className="bg-muted rounded-lg shadow p-6">


### PR DESCRIPTION
Adds the key listener for arrowup and arrowdown to flip the cards in addition to space. Closes #13